### PR TITLE
accelerate compute_state()

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -22,20 +22,24 @@ sample_variance <- function(x) {
   var(x) * (length(x) - 1L) / length(x)
 }
 
-sample_standard_deviation <- function(x) {
+sample_std_dev <- function(x) {
   sqrt(sample_variance(x))
 }
 
+# The state s is described in Section 2.3 of the original paper
 compute_state <- function(actions, resps, N_total) {
-  # Check argument
-  count_per_action <- tapply(resps, actions, length)
+  stopifnot(length(actions) == length(resps))
+  
+  resps_per_action <- split(resps, actions)
+  count_per_action <- vapply(resps_per_action, length, integer(1L), USE.NAMES = FALSE)
   stopifnot("the number of allocated subjects at each dose should be >= 2" = count_per_action >= 2L)
   
-  mean_resps <- tapply(resps, actions, mean)
+  mean_resps <- vapply(resps_per_action, mean, double(1L), USE.NAMES = FALSE)
   shifted_mean_resps <- mean_resps[-1L] - mean_resps[1L]
-  sd_resps <- tapply(resps, actions, sample_standard_deviation)
+  sd_resps <- vapply(resps_per_action, sample_std_dev, double(1L), USE.NAMES = FALSE)
   proportion_per_action <- count_per_action / N_total
-  state <- as.array(unname(c(shifted_mean_resps, sd_resps, proportion_per_action)))
+  
+  state <- as.array(c(shifted_mean_resps, sd_resps, proportion_per_action))
   state
 }
 


### PR DESCRIPTION
Make `compute_state()` 2x faster.

```r
actions <- c( 1,  1,  1,  1,  2,  2,  3,  3,  3,  4,  4,   5,  5,   5)
resps   <- c(.2, .1, .0, .3, .2, .4, .1, .6, .8, .5, .8, 1.1, .9, 1.6)

sample_standard_deviation <- RLoptimal:::sample_standard_deviation
compute_state <- RLoptimal:::compute_state

compute_state2 <- function(actions, resps, N_total) {
  resps_per_action <- split(resps, actions)
  count_per_action <- vapply(resps_per_action, length, integer(1L), USE.NAMES = FALSE)
  stopifnot("the number of allocated subjects at each dose should be >= 2" = count_per_action >= 2L)
  
  mean_resps <- vapply(resps_per_action, mean, double(1L), USE.NAMES = FALSE)
  shifted_mean_resps <- mean_resps[-1L] - mean_resps[1L]
  sd_resps <- vapply(resps_per_action, sample_standard_deviation, double(1L), USE.NAMES = FALSE)
  proportion_per_action <- count_per_action / N_total
  
  state <- as.array(c(shifted_mean_resps, sd_resps, proportion_per_action))
  state
}

identical(
  compute_state(actions, resps, 150),
  compute_state2(actions, resps, 150)
)
#> [1] TRUE

library(microbenchmark)

microbenchmark(
  compute_state = compute_state(actions, resps, 150),
  compute_state2 = compute_state2(actions, resps, 150)
)
#> Unit: microseconds
#>           expr   min     lq    mean median     uq   max neval
#>  compute_state 344.8 368.65 412.810 383.15 427.30 831.4   100
#> compute_state2 147.5 160.45 172.628 167.75 178.35 332.1   100
```